### PR TITLE
some string parsing for vpc names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,12 +17,12 @@ resource "aws_elasticache_replication_group" "redis" {
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
-  name        = "tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+  name        = "tf-redis-${var.name}-${replace(format("%.100s", lower(replace("${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
-  family      = "redis${replace(var.redis_version, "/\\.[\\d+]$/","")}" # Strip the patch version from redis_version var
+  family      = "redis${replace(var.redis_version, "/\\.[\\d]+$/","")}" # Strip the patch version from redis_version var
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
-  name       = "tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+  name       = "tf-redis-${var.name}-${replace(format("%.100s", lower(replace("${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   subnet_ids = ["${var.subnets}"]
 }

--- a/main.tf
+++ b/main.tf
@@ -17,12 +17,12 @@ resource "aws_elasticache_replication_group" "redis" {
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
-  name        = "tf-redis-${var.name}-${replace(format("%.100s", lower(replace("${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
+  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
   family      = "redis${replace(var.redis_version, "/\\.[\\d]+$/","")}" # Strip the patch version from redis_version var
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
-  name       = "tf-redis-${var.name}-${replace(format("%.100s", lower(replace("${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
+  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   subnet_ids = ["${var.subnets}"]
 }


### PR DESCRIPTION
This should clean up the VPC name string in the case where it contains
spaces, and while testing this I also fixed a regex bug for
redis_version

This should resolve #1  