### PR TITLE
Remove configuration endpoint address output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -25,6 +25,3 @@ output "port" {
 output "endpoint" {
   value = "${aws_elasticache_replication_group.redis.primary_endpoint_address}"
 }
-output "configuration_endpoint_address" {
-  value = "${aws_elasticache_replication_group.redis.configuration_endpoint_address}"
-}


### PR DESCRIPTION
This seems to trigger a terraform failure since this output isn't valid for clustered deployments.

I'm not sure whether this the right fix for the module (it works for us, but we don't use the configuration endpoint), but I thought I'd raise it as it seems the terraform provider has started to create an error when you access this value.