### PR TITLE
Removed any non-word characters from the end of replication_group_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ data "aws_vpc" "vpc" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = "${format("%.20s","${var.name}-${var.env}")}"
+  replication_group_id          = "${replace(format("%.20s","${var.name}-${var.env}"), "/\\W+$/", "")}"
   replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
   number_cache_clusters         = "${var.redis_clusters}"
   node_type                     = "${var.redis_node_type}"


### PR DESCRIPTION
As `replication_group_id` is truncated to 20 characters there is a chance that the last character might be a non-word character which is an invalid `replication_group_id`

**Example**
`hello-world-1234567-live` would get truncated to `hello-world-1234567-` and terraform would throw:

```
Error: module.redis.aws_elasticache_replication_group.redis: "replication_group_id" cannot end with a hyphen
```

This PR fixes this error by removing all non-word characters from the end of the string. Using the above example `hello-world-1234567` would be set as the `replication_group_id`.

Thank you
  