### PR TITLE
A few small documentation improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@ This module
 
 ----------------------
 #### Required
-- `env" - "env to deploy into, should typically dev/staging/prod"
-- `name` - "Name for the Redis replication group i.e. UserObject"
-- `redis_clusters` - "Number of Redis cache clusters (nodes) to create"
-- `subnets` - "List of VPC Subnet IDs for the cache subnet group"
-- `vpc_id"  - "VPC ID"
+- `env` - env to deploy into, should typically be dev/staging/prod
+- `name` - Name for the Redis replication group i.e. UserObject
+- `redis_clusters` - Number of Redis cache clusters (nodes) to create
+- `subnets` - List of VPC Subnet IDs for the cache subnet group
+- `vpc_id`  - VPC ID
 
 
 #### Optional
 
-- `apply_immediately` - "Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false."
-- `allowed_cidr` - "A list of Security Group ID's to allow access to. Defaults to localhost"
-- `allowed_security_groups` - "A list of Security Group ID's to allow access to. Defaults to empty list"
-- `redis_failover` - "Defaults to false , for failover to work, node type must larger then t2, and redis_cluster must be greater then 1"
-- `redis_node_type` - "Instance type to use for creating the Redis cache clusters Defaults to cache.m3.medium"
-- `redis_port` - "Defaults to 6379"
-- `redis_version` - "Redis version to use, defaults to 3.2.4"
+- `apply_immediately` - Specifies whether any modifications are applied immediately, or during the next maintenance window. Defaults to false.
+- `allowed_cidr` - A list of Security Group ID's to allow access to. Defaults to localhost.
+- `allowed_security_groups` - A list of Security Group ID's to allow access to. Defaults to empty list.
+- `redis_failover` - Defaults to false. For failover to work, node type must larger than t2, and redis_cluster must be greater than 1.
+- `redis_node_type` - Instance type to use for creating the Redis cache clusters. Defaults to cache.m3.medium.
+- `redis_port` - Defaults to 6379.
+- `redis_version` - Redis version to use, defaults to 3.2.4.
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Outputs
 - `id`
 - `port`
 - `endpoint`
-- `configuration_endpoint_address`
 
 
 Authors


### PR DESCRIPTION
This PR aims to improve formatting of the README a bit and remove an incorrectly documented output `configuration_endpoint_address`. It appears that this output is only available on memcached and redis-cluster EC types.