### PR TITLE
Include `env` in resource names to avoid collisions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ data "aws_vpc" "vpc" {
 
 resource "aws_elasticache_replication_group" "redis" {
   replication_group_id          = "${format("%.20s","${var.name}-${var.env}")}"
-  replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+  replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   number_cache_clusters         = "${var.redis_clusters}"
   node_type                     = "${var.redis_node_type}"
   automatic_failover_enabled    = "${var.redis_failover}"
@@ -17,12 +17,12 @@ resource "aws_elasticache_replication_group" "redis" {
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
-  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
-  description = "Terraform-managed ElastiCache parameter group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
+  description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   family      = "redis${replace(var.redis_version, "/\\.[\\d]+$/","")}" # Strip the patch version from redis_version var
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
-  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
+  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   subnet_ids = ["${var.subnets}"]
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "redis_security_group" {
-  name        = "tf-sg-ec-${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
-  description = "Terraform-managed ElastiCache security group for ${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+  name        = "${format("%.255s", "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}")}"
+  description = "Terraform-managed ElastiCache security group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   vpc_id      = "${data.aws_vpc.vpc.id}"
 
   tags {
-    Name = "tf-sg-ec-${var.name}-${data.aws_vpc.vpc.tags["Name"]}"
+    Name = "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   }
 }
 


### PR DESCRIPTION
This PR aims to namespace all resources by interpolating `${var.env}` into names or IDs so that `terraform apply` of 2 clusters with the same `name` but unique `env`s will succeed. This was previously reported as issue #10.

It does what is intended, as far as making the above possible, but please note that this path to a "fix" would be a breaking change for current users of this module. _Existing clusters will be destroyed and recreated_ if the module is upgraded, as shown below. If merged, please consider bumping the tag's major version to make this obvious/explicit.

Thanks for taking a look!

Example `terraform plan` output when upgrading to the code in this PR for `name=helloworld`, `env=production`:

```
Terraform will perform the following actions:

-/+ module.redis.aws_elasticache_parameter_group.redis_parameter_group (new resource required)
      id:                             "tf-redis-helloworld-aae-e-1" => <computed> (forces new resource)
      description:                    "Terraform-managed ElastiCache parameter group for helloworld-aae-e-1" => "Terraform-managed ElastiCache parameter group for helloworld-production-aws-us-east-1-aae-e-1" (forces new resource)
      family:                         "redis3.2" => "redis3.2"
      name:                           "tf-redis-helloworld-aae-e-1" => "tf-redis-helloworld-production-aws-us-east-1-aae-e-1" (forces new resource)

-/+ module.redis.aws_elasticache_replication_group.redis (new resource required)
      id:                             "helloworld-productio" => <computed> (forces new resource)
      apply_immediately:              "false" => "false"
      at_rest_encryption_enabled:     "false" => "false"
      auto_minor_version_upgrade:     "true" => "true"
      automatic_failover_enabled:     "true" => "true"
      configuration_endpoint_address: "" => <computed>
      engine:                         "redis" => "redis"
      engine_version:                 "3.2.10" => "3.2.10"
      maintenance_window:             "tue:06:30-tue:07:30" => <computed>
      node_type:                      "cache.m3.medium" => "cache.m3.medium"
      number_cache_clusters:          "2" => "2"
      parameter_group_name:           "tf-redis-helloworld-aae-e-1" => "${aws_elasticache_parameter_group.redis_parameter_group.id}"
      port:                           "6379" => "6379"
      primary_endpoint_address:       "helloworld-productio.rgrobr.ng.0001.use1.cache.amazonaws.com" => <computed>
      replication_group_description:  "Terraform-managed ElastiCache replication group for helloworld-aae-e-1" => "Terraform-managed ElastiCache replication group for helloworld-production-aws-us-east-1-aae-e-1"
      replication_group_id:           "helloworld-productio" => "helloworld-productio"
      security_group_ids.#:           "1" => <computed>
      security_group_names.#:         "0" => <computed>
      snapshot_window:                "03:30-04:30" => <computed>
      subnet_group_name:              "tf-redis-helloworld-aae-e-1" => "${aws_elasticache_subnet_group.redis_subnet_group.id}" (forces new resource)
      transit_encryption_enabled:     "false" => "false"

-/+ module.redis.aws_elasticache_subnet_group.redis_subnet_group (new resource required)
      id:                             "tf-redis-helloworld-aae-e-1" => <computed> (forces new resource)
      description:                    "Managed by Terraform" => "Managed by Terraform"
      name:                           "tf-redis-helloworld-aae-e-1" => "tf-redis-helloworld-production-aws-us-east-1-aae-e-1" (forces new resource)
      subnet_ids.#:                   "4" => "4"
      subnet_ids.1205371225:          "subnet-5bb10f76" => "subnet-5bb10f76"
      subnet_ids.180518870:           "subnet-e90960a0" => "subnet-e90960a0"
      subnet_ids.3476144910:          "subnet-3c51e267" => "subnet-3c51e267"
      subnet_ids.3662529929:          "subnet-ae469a92" => "subnet-ae469a92"

-/+ module.redis.aws_security_group.redis_security_group (new resource required)
      id:                             "sg-c43b98b2" => <computed> (forces new resource)
      description:                    "Terraform-managed ElastiCache security group for helloworld-aae-e-1" => "Terraform-managed ElastiCache security group for helloworld-production-aws-us-east-1-aae-e-1" (forces new resource)
      egress.#:                       "0" => <computed>
      ingress.#:                      "1" => <computed>
      name:                           "tf-sg-ec-helloworld-aae-e-1" => "tf-sg-ec-helloworld-production-aws-us-east-1-aae-e-1" (forces new resource)
      owner_id:                       "478187763210" => <computed>
      revoke_rules_on_delete:         "false" => "false"
      tags.%:                         "1" => "1"
      tags.Name:                      "tf-sg-ec-helloworld-aae-e-1" => "tf-sg-ec-helloworld-production-aws-us-east-1-aae-e-1"
      vpc_id:                         "vpc-290bf84f" => "vpc-290bf84f"

-/+ module.redis.aws_security_group_rule.redis_networks_ingress (new resource required)
      id:                             "sgrule-3167432526" => <computed> (forces new resource)
      cidr_blocks.#:                  "2" => "2"
      cidr_blocks.0:                  "192.168.5.0/24" => "192.168.5.0/24"
      cidr_blocks.1:                  "192.168.6.0/24" => "192.168.6.0/24"
      from_port:                      "6379" => "6379"
      protocol:                       "tcp" => "tcp"
      security_group_id:              "sg-c43b98b2" => "${aws_security_group.redis_security_group.id}" (forces new resource)
      self:                           "false" => "false"
      source_security_group_id:       "" => <computed>
      to_port:                        "6379" => "6379"
      type:                           "ingress" => "ingress"


Plan: 5 to add, 0 to change, 5 to destroy.
```