### PR TITLE
added module variable to modify the redis parameter group

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,47 @@ This module
 - `redis_failover` - "Defaults to false , for failover to work, node type must larger then t2, and redis_cluster must be greater then 1"
 - `redis_node_type` - "Instance type to use for creating the Redis cache clusters Defaults to cache.m3.medium"
 - `redis_port` - "Defaults to 6379"
-- `redis_version` - "Redis version to use, defaults to 3.2.4"
+- `redis_version` - "Redis version to use, defaults to 3.2.10"
+- `redis_parameters` - "The additional parameters modifyed in parameter group"
 
 Usage
 -----
 
 ```hcl
 module "redis" {
-  source         = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=1.0.0"
+  source         = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=1.2.0"
   env            = "${var.env}"
   name           = "thtest"
   redis_clusters = "2"
   redis_failover = "true"
   subnets        = "${module.vpc.database_subnets}"
   vpc_id         = "${module.vpc.vpc_id}"
+}
+```
+
+Usage with redis_parameters
+-----
+
+```hcl
+variable "redis_parameters" {
+  description = "additional parameters"
+  default = [{
+    name  = "min-slaves-max-lag"
+    value = "5"
+  },{
+    name  = "min-slaves-to-write"
+    value = "1"
+  },{
+    name  = "databases"
+    value = "32"
+  }]
+}
+
+module "redis" {
+  source           = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=1.2.0"
+  ...
+  redis_parameters = "${var.redis_parameters}"
+  ...
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ This module
 - `redis_port` - "Defaults to 6379"
 - `redis_version` - "Redis version to use, defaults to 3.2.10"
 - `redis_parameters` - "The additional parameters modifyed in parameter group"
+- `redis_maintenance_window` - "Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period"
+- `redis_snapshot_window` - "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period"
+- `redis_snapshot_retention_limit` - "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes"
 
 Usage
 -----

--- a/main.tf
+++ b/main.tf
@@ -20,6 +20,7 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
   name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   family      = "redis${replace(var.redis_version, "/\\.[\\d]+$/","")}" # Strip the patch version from redis_version var
+  parameter = "${var.redis_parameters}"
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {

--- a/main.tf
+++ b/main.tf
@@ -14,6 +14,9 @@ resource "aws_elasticache_replication_group" "redis" {
   subnet_group_name             = "${aws_elasticache_subnet_group.redis_subnet_group.id}"
   security_group_ids            = ["${aws_security_group.redis_security_group.id}"]
   apply_immediately             = "${var.apply_immediately}"
+  maintenance_window            = "${var.redis_maintenance_window}"
+  snapshot_window               = "${var.redis_snapshot_window}"
+  snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -23,6 +23,6 @@ resource "aws_security_group_rule" "redis_networks_ingress" {
   from_port                = "${var.redis_port}"
   to_port                  = "${var.redis_port}"
   protocol                 = "tcp"
-  cidr_blocks              = "${var.allowed_cidr}"
+  cidr_blocks              = ["${var.allowed_cidr}"]
   security_group_id        = "${aws_security_group.redis_security_group.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -61,7 +61,7 @@ variable "subnets" {
 # might want a map
 variable "redis_version" {
   description = "Redis version to use, defaults to 3.2.10"
-  default = "3.2.10"
+  default     = "3.2.10"
 }
 
 variable "vpc_id" {
@@ -71,5 +71,20 @@ variable "vpc_id" {
 variable "redis_parameters" {
   type = "list"
   description = "additional parameters modifyed in parameter group"
-  default = []
+  default     = []
+}
+
+variable "redis_maintenance_window" {
+  description = "Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period"
+  default     = "fri:08:00-fri:09:00"
+}
+
+variable "redis_snapshot_window" {
+  description = "The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period"
+  default     = "06:30-07:30"
+}
+
+variable "redis_snapshot_retention_limit" {
+  description = "The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes"
+  default     = 0
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,10 +60,16 @@ variable "subnets" {
 
 # might want a map
 variable "redis_version" {
-  description = "Redis version to use, defaults to 3.2.4"
-  default = "3.2.4"
+  description = "Redis version to use, defaults to 3.2.10"
+  default = "3.2.10"
 }
 
 variable "vpc_id" {
   description = "VPC ID"
+}
+
+variable "redis_parameters" {
+  type = "list"
+  description = "additional parameters modifyed in parameter group"
+  default = []
 }


### PR DESCRIPTION
1. Fixed error: `redis_networks_ingress: cidr_blocks: should be a list` if variable are the output from other module
2. Added variable to modify the redis parameter group