### PR TITLE
feat: add ability to initialize cluster with rdb snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ module "redis" {
 | redis\_port |  | string | `"6379"` | no |
 | redis\_snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes | string | `"0"` | no |
 | redis\_snapshot\_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period | string | `"06:30-07:30"` | no |
+| redis\_snapshot\_name | The name of a snapshot from which to restore data into the new node group. | string | `""` | no |
+| redis\_snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: `["arn:aws:s3:::my_bucket/snapshot1.rdb"]` | list | `[]` | no |
 | redis\_version | Redis version to use, defaults to 3.2.10 | string | `"3.2.10"` | no |
 | subnets | List of VPC Subnet IDs for the cache subnet group | list | n/a | yes |
 | tags | Tags for redis nodes | map | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,8 @@ resource "aws_elasticache_replication_group" "redis" {
   maintenance_window            = "${var.redis_maintenance_window}"
   snapshot_window               = "${var.redis_snapshot_window}"
   snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
+  snapshot_name                 = "${var.redis_snapshot_name}"
+  snapshot_arns                 = "${var.redis_snapshot_arns}"
   tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags,"Name",""))), var.tags)}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -92,6 +92,17 @@ variable "redis_snapshot_retention_limit" {
   default     = 0
 }
 
+variable "redis_snapshot_name" {
+  description = "The name of a snapshot from which to restore data into the new node group."
+  default     = ""
+}
+
+variable "redis_snapshot_arns" {
+  type        = "list"
+  description = "A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3."
+  default     = []
+}
+
 variable "tags" {
   description = "Tags for redis nodes"
   default     = {}


### PR DESCRIPTION
Added variables to be able to initialize cluster with RDS snapshots uploaded to S3:

- `redis_snapshot_name`
- `redis_snapshot_arns`