### PR TITLE
Upgrading to Terraform v0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ This module
 ```hcl
 module "redis" {
   source         = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=v1.3.0"
-  env            = "${var.env}"
+  env            = var.env
   name           = "thtest"
   redis_clusters = "2"
   redis_failover = "true"
-  subnets        = "${module.vpc.database_subnets}"
-  vpc_id         = "${module.vpc.vpc_id}"
+  subnets        = module.vpc.database_subnets
+  vpc_id         = module.vpc.vpc_id
 }
 ```
 
@@ -41,7 +41,7 @@ variable "redis_parameters" {
 module "redis" {
   source           = "github.com/terraform-community-modules/tf_aws_elasticache_redis?ref=v1.3.0"
   ...
-  redis_parameters = "${var.redis_parameters}"
+  redis_parameters = var.redis_parameters
   ...
 }
 ```

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 data "aws_vpc" "vpc" {
-  id = "${var.vpc_id}"
+  id = var.vpc_id
 }
 
 resource "random_id" "salt" {
@@ -7,34 +7,34 @@ resource "random_id" "salt" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = "${format("%.20s", "${var.name}-${var.env}")}"
+  replication_group_id          = format("%.20s", "${var.name}-${var.env}")
   replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
-  number_cache_clusters         = "${var.redis_clusters}"
-  node_type                     = "${var.redis_node_type}"
-  automatic_failover_enabled    = "${var.redis_failover}"
-  engine_version                = "${var.redis_version}"
-  port                          = "${var.redis_port}"
-  parameter_group_name          = "${aws_elasticache_parameter_group.redis_parameter_group.id}"
-  subnet_group_name             = "${aws_elasticache_subnet_group.redis_subnet_group.id}"
-  security_group_ids            = ["${aws_security_group.redis_security_group.id}"]
-  apply_immediately             = "${var.apply_immediately}"
-  maintenance_window            = "${var.redis_maintenance_window}"
-  snapshot_window               = "${var.redis_snapshot_window}"
-  snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
-  tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags, "Name", ""))), var.tags)}"
+  number_cache_clusters         = var.redis_clusters
+  node_type                     = var.redis_node_type
+  automatic_failover_enabled    = var.redis_failover
+  engine_version                = var.redis_version
+  port                          = var.redis_port
+  parameter_group_name          = aws_elasticache_parameter_group.redis_parameter_group.id
+  subnet_group_name             = aws_elasticache_subnet_group.redis_subnet_group.id
+  security_group_ids            = [aws_security_group.redis_security_group.id]
+  apply_immediately             = var.apply_immediately
+  maintenance_window            = var.redis_maintenance_window
+  snapshot_window               = var.redis_snapshot_window
+  snapshot_retention_limit      = var.redis_snapshot_retention_limit
+  tags                          = merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags, "Name", ""))), var.tags)
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
-  name = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}-${random_id.salt.hex}", "_", "-"))), "/\\s/", "-")}"
+  name = replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}-${random_id.salt.hex}", "_", "-"))), "/\\s/", "-")
 
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
 
   # Strip the patch version from redis_version var
-  family    = "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}"
+  family = "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}"
   dynamic "parameter" {
     for_each = var.redis_parameters
     content {
-      name = parameter.value.name
+      name  = parameter.value.name
       value = parameter.value.value
     }
   }
@@ -45,6 +45,6 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 }
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
-  name       = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
-  subnet_ids = "${var.subnets}"
+  name       = replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")
+  subnet_ids = var.subnets
 }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,13 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 
   # Strip the patch version from redis_version var
   family    = "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}"
-  parameter = "${var.redis_parameters}"
+  dynamic "parameter" {
+    for_each = var.redis_parameters
+    content {
+      name = parameter.value.name
+      value = parameter.value.value
+    }
+  }
 
   lifecycle {
     create_before_destroy = true

--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ resource "random_id" "salt" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = "${format("%.20s","${var.name}-${var.env}")}"
+  replication_group_id          = "${format("%.20s", "${var.name}-${var.env}")}"
   replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   number_cache_clusters         = "${var.redis_clusters}"
   node_type                     = "${var.redis_node_type}"
@@ -21,7 +21,7 @@ resource "aws_elasticache_replication_group" "redis" {
   maintenance_window            = "${var.redis_maintenance_window}"
   snapshot_window               = "${var.redis_snapshot_window}"
   snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
-  tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags,"Name",""))), var.tags)}"
+  tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, lookup(data.aws_vpc.vpc.tags, "Name", ""))), var.tags)}"
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {
@@ -30,7 +30,7 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
 
   # Strip the patch version from redis_version var
-  family    = "redis${replace(var.redis_version, "/\\.[\\d]+$/","")}"
+  family    = "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}"
   parameter = "${var.redis_parameters}"
 
   lifecycle {
@@ -40,5 +40,5 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
 
 resource "aws_elasticache_subnet_group" "redis_subnet_group" {
   name       = "${replace(format("%.255s", lower(replace("tf-redis-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}", "_", "-"))), "/\\s/", "-")}"
-  subnet_ids = ["${var.subnets}"]
+  subnet_ids = "${var.subnets}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,23 +1,23 @@
 output "redis_security_group_id" {
-  value = "${aws_security_group.redis_security_group.id}"
+  value = aws_security_group.redis_security_group.id
 }
 
 output "parameter_group" {
-  value = "${aws_elasticache_parameter_group.redis_parameter_group.id}"
+  value = aws_elasticache_parameter_group.redis_parameter_group.id
 }
 
 output "redis_subnet_group_name" {
-  value = "${aws_elasticache_subnet_group.redis_subnet_group.name}"
+  value = aws_elasticache_subnet_group.redis_subnet_group.name
 }
 
 output "id" {
-  value = "${aws_elasticache_replication_group.redis.id}"
+  value = aws_elasticache_replication_group.redis.id
 }
 
 output "port" {
-  value = "${var.redis_port}"
+  value = var.redis_port
 }
 
 output "endpoint" {
-  value = "${aws_elasticache_replication_group.redis.primary_endpoint_address}"
+  value = aws_elasticache_replication_group.redis.primary_endpoint_address
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -23,6 +23,6 @@ resource "aws_security_group_rule" "redis_networks_ingress" {
   from_port         = "${var.redis_port}"
   to_port           = "${var.redis_port}"
   protocol          = "tcp"
-  cidr_blocks       = ["${var.allowed_cidr}"]
+  cidr_blocks       = "${var.allowed_cidr}"
   security_group_id = "${aws_security_group.redis_security_group.id}"
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -3,7 +3,7 @@ resource "aws_security_group" "redis_security_group" {
   description = "Terraform-managed ElastiCache security group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   vpc_id      = "${data.aws_vpc.vpc.id}"
 
-  tags {
+  tags = {
     Name = "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
   }
 }

--- a/security_groups.tf
+++ b/security_groups.tf
@@ -1,7 +1,7 @@
 resource "aws_security_group" "redis_security_group" {
-  name        = "${format("%.255s", "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}")}"
+  name        = format("%.255s", "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}")
   description = "Terraform-managed ElastiCache security group for ${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
-  vpc_id      = "${data.aws_vpc.vpc.id}"
+  vpc_id      = data.aws_vpc.vpc.id
 
   tags = {
     Name = "tf-sg-ec-${var.name}-${var.env}-${data.aws_vpc.vpc.tags["Name"]}"
@@ -9,20 +9,20 @@ resource "aws_security_group" "redis_security_group" {
 }
 
 resource "aws_security_group_rule" "redis_ingress" {
-  count                    = "${length(var.allowed_security_groups)}"
+  count                    = length(var.allowed_security_groups)
   type                     = "ingress"
-  from_port                = "${var.redis_port}"
-  to_port                  = "${var.redis_port}"
+  from_port                = var.redis_port
+  to_port                  = var.redis_port
   protocol                 = "tcp"
-  source_security_group_id = "${element(var.allowed_security_groups, count.index)}"
-  security_group_id        = "${aws_security_group.redis_security_group.id}"
+  source_security_group_id = element(var.allowed_security_groups, count.index)
+  security_group_id        = aws_security_group.redis_security_group.id
 }
 
 resource "aws_security_group_rule" "redis_networks_ingress" {
   type              = "ingress"
-  from_port         = "${var.redis_port}"
-  to_port           = "${var.redis_port}"
+  from_port         = var.redis_port
+  to_port           = var.redis_port
   protocol          = "tcp"
-  cidr_blocks       = "${var.allowed_cidr}"
-  security_group_id = "${aws_security_group.redis_security_group.id}"
+  cidr_blocks       = var.allowed_cidr
+  security_group_id = aws_security_group.redis_security_group.id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,13 +20,13 @@ variable "apply_immediately" {
 }
 
 variable "allowed_cidr" {
-  type        = "list"
+  type        = list
   default     = ["127.0.0.1/32"]
   description = "A list of Security Group ID's to allow access to."
 }
 
 variable "allowed_security_groups" {
-  type        = "list"
+  type        = list
   default     = []
   description = "A list of Security Group ID's to allow access to."
 }
@@ -57,7 +57,7 @@ variable "redis_port" {
 }
 
 variable "subnets" {
-  type        = "list"
+  type        = list
   description = "List of VPC Subnet IDs for the cache subnet group"
 }
 
@@ -72,7 +72,7 @@ variable "vpc_id" {
 }
 
 variable "redis_parameters" {
-  type        = list(object({name = string, value = string}))
+  type        = list(object({ name = string, value = string }))
   description = "additional parameters modifyed in parameter group"
   default     = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,13 +20,13 @@ variable "apply_immediately" {
 }
 
 variable "allowed_cidr" {
-  type        = list
+  type        = list(string)
   default     = ["127.0.0.1/32"]
   description = "A list of Security Group ID's to allow access to."
 }
 
 variable "allowed_security_groups" {
-  type        = list
+  type        = list(string)
   default     = []
   description = "A list of Security Group ID's to allow access to."
 }
@@ -57,7 +57,7 @@ variable "redis_port" {
 }
 
 variable "subnets" {
-  type        = list
+  type        = list(string)
   description = "List of VPC Subnet IDs for the cache subnet group"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,7 @@ variable "redis_snapshot_retention_limit" {
 }
 
 variable "tags" {
+  type        = map(string)
   description = "Tags for redis nodes"
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -72,7 +72,7 @@ variable "vpc_id" {
 }
 
 variable "redis_parameters" {
-  type        = "list"
+  type        = list(object({name = string, value = string}))
   description = "additional parameters modifyed in parameter group"
   default     = []
 }

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
Terraform 0.12 requires strict typing for variables and also, the dynamic blocks are to be handled differently. This PR fixes all the aforementioned issues.