### PR TITLE
add auto_minor_version_upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ module "redis" {
 | name | Name for the Redis replication group i.e. UserObject | string | n/a | yes |
 | redis\_clusters | Number of Redis cache clusters (nodes) to create | string | n/a | yes |
 | redis\_failover |  | bool | `"false"` | no |
-| redis\_maintenance\_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period | string | `"fri:08:00-fri:09:00"` | no |
+| redis\_failover |  | bool | `"false"` | no |
+| auto\_minor\_version\_upgrade | Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window  | bool | `"true"` | no |
 | redis\_node\_type | Instance type to use for creating the Redis cache clusters | string | `"cache.m3.medium"` | no |
 | redis\_parameters | additional parameters modifyed in parameter group | list(map(any)) | `[]` | no |
 | redis\_port |  | number | `"6379"` | no |

--- a/main.tf
+++ b/main.tf
@@ -12,6 +12,7 @@ resource "aws_elasticache_replication_group" "redis" {
   number_cache_clusters         = var.redis_clusters
   node_type                     = var.redis_node_type
   automatic_failover_enabled    = var.redis_failover
+  auto_minor_version_upgrade    = var.auto_minor_version_upgrade
   engine_version                = var.redis_version
   port                          = var.redis_port
   parameter_group_name          = aws_elasticache_parameter_group.redis_parameter_group.id

--- a/variables.tf
+++ b/variables.tf
@@ -51,6 +51,10 @@ variable "redis_failover" {
   type    = bool
   default = false
 }
+variable "auto_minor_version_upgrade" {
+  type    = bool
+  default = true
+}
 
 variable "redis_node_type" {
   description = "Instance type to use for creating the Redis cache clusters"


### PR DESCRIPTION
Added the capability to define whether automatic minor version of Redis should be updated automatically over next maintenance window or not