### PR TITLE
Conditionally update random_id

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,9 @@ data "aws_vpc" "vpc" {
 
 resource "random_id" "salt" {
   byte_length = 8
+  keepers = {
+    redis_version = var.redis_version
+  }
 }
 
 resource "aws_elasticache_replication_group" "redis" {


### PR DESCRIPTION
problem:

when `redis_version` changes, a new `redis_parameter_group` needs to be created
`redis_parameter_group` uses the `create_before_destroy` lifecycle rule so the new parameter group needs to have a distinct name from the existing one

currently the `random_id` never changes after it has been created, which means that the parameter group names will conflict

solution:

use the `keepers` argument to `random_id` so that its value is changed whenever the value of `redis_version` is changed
https://www.terraform.io/docs/providers/random/r/id.html#keepers