### PR TITLE
fix: add redis_version keeper for random_id.salt

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,6 +8,10 @@ locals {
 
 resource "random_id" "salt" {
   byte_length = 8
+
+  keepers {
+    redis_version = "${var.redis_version}"
+  }
 }
 
 resource "aws_elasticache_replication_group" "redis" {


### PR DESCRIPTION
Same as https://github.com/terraform-community-modules/tf_aws_elasticache_redis/pull/38 , but for tf0.11