### PR TITLE
Add new arguments support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,16 @@ module "redis" {
 | allowed\_cidr | A list of Security Group ID's to allow access to. | list | `[ "127.0.0.1/32" ]` | no |
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | list | `[]` | no |
 | apply\_immediately | Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false. | string | `"false"` | no |
+| at\_rest\_encryption\_enabled | Whether to enable encryption at rest | string | `false` | no |
+| auth\_token | The password used to access a password protected server. Can be specified only if transit_encryption_enabled = true. If specified must contain from 16 to 128 alphanumeric characters or symbols | string | `""` | no |
+| auto\_minor\_version\_upgrade | Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window | string | `true` | no |
+| availability\_zones | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important | list | `<list>` | no |
 | env | env to deploy into, should typically dev/staging/prod | string | n/a | yes |
+| kms\_key\_id | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at_rest_encryption_enabled = true | string | `""` | no |
 | name | Name for the Redis replication group i.e. UserObject | string | n/a | yes |
+| notification\_topic\_arn | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: arn:aws:sns:us-east-1:012345678999:my_sns_topic | string | `""` | no |
 | redis\_clusters | Number of Redis cache clusters (nodes) to create | string | n/a | yes |
-| redis\_failover |  | string | `"false"` | no |
+| redis\_failover |  | string | `false` | no |
 | redis\_maintenance\_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period | string | `"fri:08:00-fri:09:00"` | no |
 | redis\_node\_type | Instance type to use for creating the Redis cache clusters | string | `"cache.m3.medium"` | no |
 | redis\_parameters | additional parameters modifyed in parameter group | list | `[]` | no |
@@ -71,8 +77,12 @@ module "redis" {
 | redis\_snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot_retention_limit is not supported on cache.t1.micro or cache.t2.* cache nodes | string | `"0"` | no |
 | redis\_snapshot\_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period | string | `"06:30-07:30"` | no |
 | redis\_version | Redis version to use, defaults to 3.2.10 | string | `"3.2.10"` | no |
+| security\_group\_names | A list of cache security group names to associate with this replication group | list | `[]` | no |
+| snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb | list | `[]` | no |
+| snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot_name forces a new resource | string | `""` | no |
 | subnets | List of VPC Subnet IDs for the cache subnet group | list | n/a | yes |
 | tags | Tags for redis nodes | map | `{}` | no |
+| transit\_encryption\_enabled | Whether to enable encryption in transit. Requires 3.2.6 or >=4.0 redis_version | string | `false` | no |
 | vpc\_id | VPC ID | string | n/a | yes |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ module "redis" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| allowed\_cidr | A list of Security Group ID's to allow access to. | list | `[ "127.0.0.1/32" ]` | no |
+| allowed\_cidr | A list of CIDR blocks to allow access from. | list | `[ "127.0.0.1/32" ]` | no |
 | allowed\_security\_groups | A list of Security Group ID's to allow access to. | list | `[]` | no |
 | apply\_immediately | Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false. | string | `"false"` | no |
 | at\_rest\_encryption\_enabled | Whether to enable encryption at rest | string | `false` | no |

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -18,7 +18,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   threshold = "${var.alarm_cpu_threshold}"
 
   dimensions {
-    CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
+    CacheClusterId = "${local.redis_id}-00${count.index + 1}"
   }
 
   alarm_actions = ["${var.alarm_actions}"]
@@ -39,7 +39,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   threshold = "${var.alarm_memory_threshold}"
 
   dimensions {
-    CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
+    CacheClusterId = "${local.redis_id}-00${count.index + 1}"
   }
 
   alarm_actions = ["${var.alarm_actions}"]

--- a/main.tf
+++ b/main.tf
@@ -11,21 +11,69 @@ resource "random_id" "salt" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
+  count = "${length(var.auth_token) > 0 && var.transit_encryption_enabled ? 0 : 1}"
+
   replication_group_id          = "${format("%.20s","${var.name}-${var.env}")}"
   replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${local.vpc_name}"
   number_cache_clusters         = "${var.redis_clusters}"
   node_type                     = "${var.redis_node_type}"
   automatic_failover_enabled    = "${var.redis_failover}"
+  auto_minor_version_upgrade    = "${var.auto_minor_version_upgrade}"
+  availability_zones            = "${var.availability_zones}"
+  engine                        = "redis"
+  at_rest_encryption_enabled    = "${var.at_rest_encryption_enabled}"
+  kms_key_id                    = "${var.kms_key_id}"
+  transit_encryption_enabled    = "${var.transit_encryption_enabled}"
   engine_version                = "${var.redis_version}"
   port                          = "${var.redis_port}"
   parameter_group_name          = "${aws_elasticache_parameter_group.redis_parameter_group.id}"
   subnet_group_name             = "${aws_elasticache_subnet_group.redis_subnet_group.id}"
+  security_group_names          = "${var.security_group_names}"
   security_group_ids            = ["${aws_security_group.redis_security_group.id}"]
+  snapshot_arns                 = "${var.snapshot_arns}"
+  snapshot_name                 = "${var.snapshot_name}"
   apply_immediately             = "${var.apply_immediately}"
   maintenance_window            = "${var.redis_maintenance_window}"
+  notification_topic_arn        = "${var.notification_topic_arn}"
   snapshot_window               = "${var.redis_snapshot_window}"
   snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
   tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, local.vpc_name)), var.tags)}"
+}
+
+resource "aws_elasticache_replication_group" "redis_auth" {
+  count = "${length(var.auth_token) > 0 && var.transit_encryption_enabled ? 1 : 0}"
+
+  replication_group_id          = "${format("%.20s","${var.name}-${var.env}")}"
+  replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${local.vpc_name}"
+  number_cache_clusters         = "${var.redis_clusters}"
+  node_type                     = "${var.redis_node_type}"
+  automatic_failover_enabled    = "${var.redis_failover}"
+  auto_minor_version_upgrade    = "${var.auto_minor_version_upgrade}"
+  availability_zones            = "${var.availability_zones}"
+  engine                        = "redis"
+  at_rest_encryption_enabled    = "${var.at_rest_encryption_enabled}"
+  kms_key_id                    = "${var.kms_key_id}"
+  transit_encryption_enabled    = "${var.transit_encryption_enabled}"
+  auth_token                    = "${var.auth_token}"
+  engine_version                = "${var.redis_version}"
+  port                          = "${var.redis_port}"
+  parameter_group_name          = "${aws_elasticache_parameter_group.redis_parameter_group.id}"
+  subnet_group_name             = "${aws_elasticache_subnet_group.redis_subnet_group.id}"
+  security_group_names          = "${var.security_group_names}"
+  security_group_ids            = ["${aws_security_group.redis_security_group.id}"]
+  snapshot_arns                 = "${var.snapshot_arns}"
+  snapshot_name                 = "${var.snapshot_name}"
+  apply_immediately             = "${var.apply_immediately}"
+  maintenance_window            = "${var.redis_maintenance_window}"
+  notification_topic_arn        = "${var.notification_topic_arn}"
+  snapshot_window               = "${var.redis_snapshot_window}"
+  snapshot_retention_limit      = "${var.redis_snapshot_retention_limit}"
+  tags                          = "${merge(map("Name", format("tf-elasticache-%s-%s", var.name, local.vpc_name)), var.tags)}"
+}
+
+locals {
+  redis_id                       = "${join("", concat(aws_elasticache_replication_group.redis.*.id, aws_elasticache_replication_group.redis_auth.*.id))}"
+  redis_primary_endpoint_address = "${join("", concat(aws_elasticache_replication_group.redis.*.primary_endpoint_address, aws_elasticache_replication_group.redis_auth.*.primary_endpoint_address))}"
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -11,7 +11,7 @@ output "redis_subnet_group_name" {
 }
 
 output "id" {
-  value = "${aws_elasticache_replication_group.redis.id}"
+  value = "${local.redis_id}"
 }
 
 output "port" {
@@ -19,5 +19,5 @@ output "port" {
 }
 
 output "endpoint" {
-  value = "${aws_elasticache_replication_group.redis.primary_endpoint_address}"
+  value = "${local.redis_primary_endpoint_address}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -96,3 +96,56 @@ variable "tags" {
   description = "Tags for redis nodes"
   default     = {}
 }
+
+variable "auto_minor_version_upgrade" {
+  description = "Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window"
+  default     = true
+}
+
+variable "availability_zones" {
+  description = "A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important"
+  type        = "list"
+  default     = []
+}
+
+variable "at_rest_encryption_enabled" {
+  description = "Whether to enable encryption at rest"
+  default     = false
+}
+
+variable "kms_key_id" {
+  description = "The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at_rest_encryption_enabled = true"
+  default     = ""
+}
+
+variable "transit_encryption_enabled" {
+  description = "Whether to enable encryption in transit. Requires 3.2.6 or >=4.0 redis_version"
+  default     = false
+}
+
+variable "auth_token" {
+  description = "The password used to access a password protected server. Can be specified only if transit_encryption_enabled = true. If specified must contain from 16 to 128 alphanumeric characters or symbols"
+  default     = ""
+}
+
+variable "security_group_names" {
+  description = "A list of cache security group names to associate with this replication group"
+  type        = "list"
+  default     = []
+}
+
+variable "snapshot_arns" {
+  description = "A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my_bucket/snapshot1.rdb"
+  type        = "list"
+  default     = []
+}
+
+variable "snapshot_name" {
+  description = " The name of a snapshot from which to restore data into the new node group. Changing the snapshot_name forces a new resource"
+  default     = ""
+}
+
+variable "notification_topic_arn" {
+  description = "An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: arn:aws:sns:us-east-1:012345678999:my_sns_topic"
+  default     = ""
+}

--- a/variables.tf
+++ b/variables.tf
@@ -22,7 +22,7 @@ variable "apply_immediately" {
 variable "allowed_cidr" {
   type        = "list"
   default     = ["127.0.0.1/32"]
-  description = "A list of Security Group ID's to allow access to."
+  description = "A list of CIDR blocks to allow access from."
 }
 
 variable "allowed_security_groups" {


### PR DESCRIPTION
For terraform v0.11

Will:
* add support for arguments:
  - at_rest_encryption_enabled
  - auth_token
  - auto_minor_version_upgrade
  - availability_zones
  - kms_key_id
  - notification_topic_arn
  - security_group_names
  - snapshot_arns
  - snapshot_name
  - transit_encryption_enabled

* fix description of 'allowed_cidr' variable

* make changes for `terraform011` branch requested in PRs:
  - #37
  - #33
  - #28
  - #29
  - #27
  - #23

 - [X] Doesn't break compatibility with previous v1 releases