### PR TITLE
fix: Make aws_elasticache_parameter_group to use redis6.x as value for family when version is 6 and above

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,6 +4,7 @@ data "aws_vpc" "vpc" {
 
 locals {
   vpc_name = lookup(data.aws_vpc.vpc.tags, "Name", var.vpc_id)
+  parameter_group_family = substr(var.redis_version, 0,1) < 6 ?  "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}": "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}.x"
 }
 
 resource "random_id" "salt" {
@@ -49,7 +50,7 @@ resource "aws_elasticache_parameter_group" "redis_parameter_group" {
   description = "Terraform-managed ElastiCache parameter group for ${var.name}-${var.env}-${local.vpc_name}"
 
   # Strip the patch version from redis_version var
-  family = "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}"
+  family = local.parameter_group_family
   dynamic "parameter" {
     for_each = var.redis_parameters
     content {


### PR DESCRIPTION
**Problem:** 
The latest version of this module did not seem to work for recent version of Redis, which is 6.0 and 6.2. Since the recent versions do not have the patch version in them, resulting string is becoming "redis6", which is not a valid input for family input of aws_elasticache_parameter_group resource. 

**Proposed Solution:**
For redis 6.x, the valid family value is **redis6.x**. So when the redis version is 6 and above, it is concatenating '.x' to the end of this resulting string. This solved the issue for me. But please let me know if you think this can be addressed in a more elegant way.

