### PR TITLE
[bug] Fix version 6.x and 7.0 in parameter group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,8 @@ data "aws_vpc" "vpc" {
 
 locals {
   vpc_name = lookup(data.aws_vpc.vpc.tags, "Name", var.vpc_id)
-  parameter_group_family = substr(var.redis_version, 0,1) < 6 ?  "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}": "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}.x"
+  major_redis_version = parseint(substr(var.redis_version, 0,1),10)
+  parameter_group_family = local.major_redis_version < 6 ?  "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}" : local.major_redis_version == 6 ? "redis${replace(var.redis_version, "/\\.[\\d|x]+$/", "")}.x" : "redis${local.major_redis_version}"
 }
 
 resource "random_id" "salt" {


### PR DESCRIPTION
Right now support for `6.x` and `7.0` versions is broken in this module, as it's referencing an non-existing parameter group.

I went to the current AWS versions and I did a mapping with the `parameter_group_family` :

```
3.2.4 => redis3.2
3.2.6 => redis3.2
3.2.10 => redis3.2
4.0.10 => redis4.0
5.0.6 => redis5.0
6.0 => redis6.x
6.2 => redis6.x
6.x => redis6.x
7.0 => redis7
```

This is the tests I performed with the current code in repository:

```bash
❯ for version in 3.2.4 3.2.6 3.2.10 4.0.10 5.0.6 6.0 6.2 6.x 7.0; do
     echo "local.parameter_group_family_old" | TF_VAR_redis_version="$version" terraform console
   done

"redis3.2"
"redis3.2"
"redis3.2"
"redis4.0"
"redis5.0"
"redis6.x"
"redis6.x"
"redis6.x.x"
"redis7.x"
```

As you can see, `6.x` and `7.0` versions are wrong ( last two lines )

With my path produces the following result:

```bash
❯ for version in 3.2.4 3.2.6 3.2.10 4.0.10 5.0.6 6.0 6.2 6.x 7.0; do
     echo "local.parameter_group_family" | TF_VAR_redis_version="$version" terraform console
   done

"redis3.2"
"redis3.2"
"redis3.2"
"redis4.0"
"redis5.0"
"redis6.x"
"redis6.x"
"redis6.x"
"redis7"
```

Which matches with the manual mapping in the beginning of the post.

@antonbabenko let me know if you need anything else.
